### PR TITLE
Follow-up: Switch to AAPT2

### DIFF
--- a/common/install.sh
+++ b/common/install.sh
@@ -162,13 +162,11 @@ download_install_webview() {
 create_overlay() {
 	echo "[$(date "+%H:%M:%S")] Create overlay" >>$LOG
 	ui_print "  Creating overlay..."
-	unzip -qo "$MODPATH"/overlays/$OVERLAY_ZIP_FILE -d "$MODPATH"/overlays/overlay >&2
-	MODTMPDIR="$(mktemp -d)"
-	if [ -n "$MODTMPDIR" ] && [ -d "$MODTMPDIR" ]; then
-		aapt2 compile -v --dir "$MODPATH"/overlays/overlay/res -o "$MODTMPDIR" && \
-			aapt2 link -o "$MODPATH"/unsigned.apk -I /system/framework/framework-res.apk --manifest "$MODPATH"/overlays/overlay/AndroidManifest.xml "$MODTMPDIR"/* >&2
-		rm -rf "$MODTMPDIR"
-	fi
+	local WORKDIR="$MODPATH"/overlays/overlay
+	unzip -qo "$MODPATH"/overlays/$OVERLAY_ZIP_FILE -d "$WORKDIR" >&2
+	mkdir -p "$WORKDIR"/build
+	aapt2 compile -v --dir "$WORKDIR"/res -o "$WORKDIR"/build && \
+		aapt2 link -o "$MODPATH"/unsigned.apk -I /system/framework/framework-res.apk --manifest "$WORKDIR"/AndroidManifest.xml "$WORKDIR"/build/* >&2
 }
 sign_framework_res() {
 	echo "[$(date "+%H:%M:%S")] Sign modified framework-res" >>$LOG


### PR DESCRIPTION
As explained in https://github.com/Magisk-Modules-Alt-Repo/open_webview/issues/51#issuecomment-2558281854 `mktemp` doesn't work on all versions of Android as I previously expected.  
It can be fixed with the use of the `-p` argument, but at this point it's better to just not use it.

Apologies for incomplete testing last time.