### PR TITLE
Update Cromite APK URL

### DIFF
--- a/common/install.sh
+++ b/common/install.sh
@@ -61,7 +61,7 @@ vanadium() {
 	OVERLAY_ZIP_FILE="vanadium-overlay${OVERLAY_API}.zip"
 }
 cromite() {
-	VW_APK_URL=https://github.com/uazo/cromite/releases/download/$(get_version_github "uazo/cromite" "${ARCH}_SystemWebView64.apk")/${ARCH}_SystemWebView64.apk
+	VW_APK_URL=https://github.com/uazo/cromite/releases/download/$(get_version_github "uazo/cromite" "${ARCH}_SystemWebView.apk")/${ARCH}_SystemWebView.apk
 	VW_TRICHROME_APK_URL=""
 	VW_SHA=""
 	VW_SYSTEM_PATH=""


### PR DESCRIPTION
Because the downloading function is not working properly, This pr corrects the url of apkfile.

${ARCH}_SystemWebView64.apk -> ${ARCH}_SystemWebView.apk

In this time, The naming of webview apk from https://github.com/uazo/cromite/releases is changed like above. 

Thx